### PR TITLE
Removing react-native-flip-card library

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "react": "16.3.1",
     "react-native": "~0.55.2",
     "react-native-animatable": "^1.3.0",
-    "react-native-flip-card": "^3.5.2",
     "react-native-qrcode": "^0.2.6",
     "react-navigation": "^2.5.5",
     "react-redux": "^5.0.7",

--- a/src/views/Card/index.js
+++ b/src/views/Card/index.js
@@ -1,14 +1,39 @@
 import React, { Component } from 'react';
-import { Image } from 'react-native';
+import { Image, TouchableWithoutFeedback } from 'react-native';
 import {
   Container, Content, Card as NativeBaseCard, CardItem, Body, Text
 } from 'native-base';
-import FlipCard from 'react-native-flip-card';
 import { connect } from 'react-redux';
 import { AppLoading, Asset, Constants } from 'expo';
 import propTypes from 'prop-types';
+import * as Animatable from 'react-native-animatable';
 import styles from './styles';
 import back from '../../assets/back.jpeg';
+
+Animatable.initializeRegistryWithDefinitions({
+  flipCard: {
+    easing: 'ease-in',
+    style: {
+      backfaceVisibility: 'visible',
+      perspective: 400,
+    },
+    0: {
+      rotateY: '90deg',
+    },
+    0.4: {
+      rotateY: '-20deg',
+    },
+    0.6: {
+      rotateY: '10deg',
+    },
+    0.8: {
+      rotateY: '-5deg',
+    },
+    1: {
+      rotateY: '0deg',
+    },
+  },
+});
 
 function cacheImages(images) {
   return images.map((image) => {
@@ -28,18 +53,30 @@ class Card extends Component {
     super();
     this.state = {
       isReady: false,
+      isFlipped: false,
     };
+    this.image = {};
   }
 
   loadAssetsAsync = front => async () => {
     const imageAssets = cacheImages([front, back]);
-
     await Promise.all([...imageAssets]);
+  };
+
+  handleRef = (ref) => {
+    this.image = ref;
+  };
+
+  handlePress = () => {
+    const { isFlipped } = this.state;
+    this.setState({ isFlipped: !isFlipped });
+    this.image.flipCard();
   };
 
   render() {
     const { card, alive } = this.props;
-    const { isReady } = this.state;
+    const { isReady, isFlipped } = this.state;
+    const isFrontVisible = isFlipped || !alive;
 
     if (!isReady) {
       return (
@@ -53,31 +90,26 @@ class Card extends Component {
     return (
       <Container>
         <Content>
-          <FlipCard
-            flipHorizontal
-            flipVertical={false}
-            clickable={alive}
-            flip={!alive}
-            perspective={1000}
-            useNativeDriver
-          >
-            <NativeBaseCard>
-              <CardItem style={styles.card}>
-                <Body>
-                  <Image source={back} style={styles.cardImage} />
-                </Body>
-              </CardItem>
-            </NativeBaseCard>
-            <NativeBaseCard>
-              <CardItem style={styles.card}>
-                <Body>
-                  <Image source={{ uri: card.url }} style={styles.cardImage} />
-                  <Text style={styles.role}>{card.role}</Text>
-                  <Text style={styles.description}>{card.description}</Text>
-                </Body>
-              </CardItem>
-            </NativeBaseCard>
-          </FlipCard>
+          <TouchableWithoutFeedback onPress={this.handlePress}>
+            <Animatable.View ref={this.handleRef}>
+              <NativeBaseCard>
+                <CardItem style={styles.card}>
+                  <Body>
+                    <Image
+                      source={{ uri: card.url }}
+                      style={isFrontVisible ? styles.cardImage : styles.imageHidden}
+                    />
+                    <Image
+                      source={back}
+                      style={isFrontVisible ? styles.imageHidden : styles.cardImage}
+                    />
+                    {isFrontVisible && <Text style={styles.role}>{card.role}</Text>}
+                    {isFrontVisible && <Text style={styles.description}>{card.description}</Text>}
+                  </Body>
+                </CardItem>
+              </NativeBaseCard>
+            </Animatable.View>
+          </TouchableWithoutFeedback>
         </Content>
       </Container>
     );

--- a/src/views/Card/styles.js
+++ b/src/views/Card/styles.js
@@ -5,6 +5,9 @@ export default StyleSheet.create({
     width: '100%',
     height: 600,
   },
+  imageHidden: {
+    display: 'none',
+  },
   card: {
     backgroundColor: '#101f21',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6453,12 +6453,6 @@ react-native-easy-grid@0.2.0:
   dependencies:
     lodash "^4.11.1"
 
-react-native-flip-card@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/react-native-flip-card/-/react-native-flip-card-3.5.2.tgz#6563f4a6d95b999c21e82deec9b2f502175847d6"
-  dependencies:
-    prop-types "^15.5.10"
-
 react-native-gesture-handler@1.0.0-alpha.41:
   version "1.0.0-alpha.41"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0-alpha.41.tgz#5667a1977ab148339ec2e7b0a94ad4b959cf09e5"


### PR DESCRIPTION
We decided to use react-native-animatable because the animation is more fluid than the current and we already had the library.

![gif-2018-10-31-21-55-40](https://user-images.githubusercontent.com/6082977/47828387-3b35a780-dd59-11e8-8f6e-0968c877ee80.gif)
