### PR TITLE
Update splash image and renaming component.

### DIFF
--- a/App.js
+++ b/App.js
@@ -11,7 +11,7 @@ import NavigationService from './src/navigation';
 // Views
 import Card from './src/views/Card';
 import Game from './src/views/Game';
-import Splash from './src/views/Splash';
+import DeepLinkManager from './src/views/DeepLinkManager';
 import Party from './src/views/Party';
 import Join from './src/views/Join';
 import Lobby from './src/views/Lobby';
@@ -21,14 +21,14 @@ const AppNavigator = createStackNavigator(
   {
     Card,
     Game,
-    Splash,
+    DeepLinkManager,
     Party,
     Join,
     Lobby,
     Prepare,
   },
   {
-    initialRouteName: 'Splash',
+    initialRouteName: 'DeepLinkManager',
     defaultNavigationOptions: {
       gesturesEnabled: false,
       headerLeft: null,

--- a/src/views/DeepLinkManager/index.js
+++ b/src/views/DeepLinkManager/index.js
@@ -2,13 +2,12 @@ import React, { Component } from 'react';
 import { Linking as ExpoLink } from 'expo';
 import { connect } from 'react-redux';
 import { Linking, Image } from 'react-native';
-import { Container, Content } from 'native-base';
 import propTypes from 'prop-types';
 import * as Actions from '../../actions';
 import NavigationService from '../../navigation';
 import styles from './styles';
 
-class Splash extends Component {
+class DeepLinkManager extends Component {
   componentDidMount() {
     Linking.addEventListener('url', ({ url }) => this.handleOpenURL(url));
     Linking.getInitialURL().then(this.handleOpenURL);
@@ -32,17 +31,11 @@ class Splash extends Component {
   };
 
   render() {
-    return (
-      <Container>
-        <Content contentContainerStyle={styles.content}>
-          <Image source={require('../../assets/full-moon.jpg')} />
-        </Content>
-      </Container>
-    );
+    return <Image style={styles.img} source={require('../../assets/icon.png')} />;
   }
 }
 
-Splash.propTypes = {
+DeepLinkManager.propTypes = {
   navigation: propTypes.shape({
     navigate: propTypes.func,
   }).isRequired,
@@ -54,4 +47,4 @@ const mapDispatchToProps = { joinParty: Actions.joinParty };
 export default connect(
   null,
   mapDispatchToProps
-)(Splash);
+)(DeepLinkManager);

--- a/src/views/DeepLinkManager/styles.js
+++ b/src/views/DeepLinkManager/styles.js
@@ -1,10 +1,10 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  content: {
+  img: {
     flex: 1,
-    backgroundColor: '#000',
-    alignItems: 'center',
-    justifyContent: 'center',
+    width: null,
+    height: null,
+    resizeMode: 'contain',
   },
 });


### PR DESCRIPTION
In this pull request, I'm updating the splash image (see below) and renaming the Splash to DeepLinkManager to avoid confusion between the component and the expo's Splash (look at the app.json file).

<img width="427" alt="werewolf icon" src="https://user-images.githubusercontent.com/6082977/53542904-f51a0600-3af6-11e9-8542-957c27865c83.png">
